### PR TITLE
replace .read() with .set()

### DIFF
--- a/relabel.ipynb
+++ b/relabel.ipynb
@@ -20,21 +20,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "movie_file = '/home/sneufeld/Downloads/Basler_acA1300-60gm__21503351__20191212_131714734.mp4'\n",
-    "labels_file = '/home/sneufeld/Downloads/Basler-acA1300-labels-mashbayar.csv'\n",
-    "batch_size = 250"
+    "movie_file = '/home/mmiller/Documents/data/imuNet_data/om_20191212/Basler_acA1300-60gm__21503351__20191212_131714734.mp4'\n",
+    "labels_file = '/home/mmiller/Documents/data/imuNet_data/om_20191212/label_mm_bck.csv'\n",
+    "batch_size = 500"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stdin",
      "output_type": "stream",
      "text": [
-      "What frame do you want to start relabeling? [enter an integer]:  0\n"
+      "What frame do you want to start relabeling? [enter an integer]:  500\n"
      ]
     },
     {
@@ -66,41 +66,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a4e0b4a2a4a442f2b9f36cbcd57f3349",
+       "model_id": "9b3bdc0495dc4e1c9fc08f8bcbdf5ffa",
        "version_major": 2,
        "version_minor": 0
       },
       "text/plain": [
-       "HBox(children=(IntProgress(value=0, max=250), HTML(value='')))"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stdin",
-     "output_type": "stream",
-     "text": [
-      "Save labels? [y/n]:  y\n",
-      "Label next batch? [y/n]:  y\n"
-     ]
-    },
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "997c44fbac164bd483ebf5f079eae2f4",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "HBox(children=(IntProgress(value=0, max=250), HTML(value='')))"
+       "HBox(children=(IntProgress(value=0, max=500), HTML(value='')))"
       ]
      },
      "metadata": {},

--- a/videolabeler/utils.py
+++ b/videolabeler/utils.py
@@ -212,8 +212,7 @@ def interpolate_labels(labels):
     ['walking','INTERP','0','0','walking','0','walking']
 
     This function looks for frames labeled INTERP, and then applies the label from the frame
-    immediately before to all the frames up until the next label. The next label must be 
-    identical to the previous one, or else the interpolation fails. 
+    immediately before to all the frames up until the next label. 
 
     The output of the above labels after interpolation would be:
     ['walking','walking','walking','walking','0','walking']
@@ -234,9 +233,10 @@ def interpolate_labels(labels):
         next_labeled_frame = labeled_frames[np.where(labeled_frames > interp_frame)[0][0]]
         next_label = labels[next_labeled_frame]
 
-        assert label == next_label,'Interpolation failed because labels do not match'
+        #assert label == next_label,'Interpolation failed because labels do not match'
+        
 
-        labels_interp[interp_frame:next_labeled_frame] = label
+        labels_interp[interp_frame:next_labeled_frame-1] = label
         
     return labels_interp
 

--- a/videolabeler/utils.py
+++ b/videolabeler/utils.py
@@ -369,7 +369,7 @@ def batchFrameLabel(video_file,labels_file,batch_size,n_overlap_frames=10,
 
         # Read in video batch
         if current_batch == batch_starts[-1]:
-            n_frames_to_read = n_frames - current_batch
+            n_frames_to_read = int(n_frames - current_batch)
         else:
             n_frames_to_read = batch_size
         frames = []

--- a/videolabeler/utils.py
+++ b/videolabeler/utils.py
@@ -374,12 +374,22 @@ def batchFrameLabel(video_file,labels_file,batch_size,n_overlap_frames=10,
         else:
             n_frames_to_read = batch_size
         frames = []
-
-        for i in tqdm(range(n_frames_to_read)):
+        
+        # access each frame with video.set() to avoid dropped frames in stream()
+        frames_to_read = np.arange(current_batch, current_batch + n_frames_to_read, 1)
+        for i in tqdm(frames_to_read):
+            video.set(cv2.CAP_PROP_POS_FRAMES,i)
             ret, frame = video.read()
             gray=cv2.cvtColor(frame,cv2.COLOR_BGR2GRAY)
             frames.append(gray)
             key = cv2.waitKey(1)
+            
+                
+        #for i in tqdm(range(n_frames_to_read)):
+        #    ret, frame = video.read()
+        #    gray=cv2.cvtColor(frame,cv2.COLOR_BGR2GRAY)
+        #    frames.append(gray)
+        #    key = cv2.waitKey(1)
 
         # Label Frames
         label_list = PlayAndLabelFrames(frames,label_dict=label_dict,overlap_labels=overlap_labels,return_labeled_frames=False)
@@ -507,11 +517,20 @@ def relabelFrames(video_file,labels_file,batch_size,n_overlap_frames=10,
             end_labeling = False
         
         frames = []
-        for i in tqdm(range(n_frames_to_read)):
+        # access each frame with video.set() to avoid dropped frames in stream()
+        frames_to_read = np.arange(batch_start_frame, batch_start_frame + n_frames_to_read, 1)
+        for i in tqdm(frames_to_read):
+            video.set(cv2.CAP_PROP_POS_FRAMES,i)
             ret, frame = video.read()
             gray=cv2.cvtColor(frame,cv2.COLOR_BGR2GRAY)
             frames.append(gray)
             key = cv2.waitKey(1)
+        
+        #for i in tqdm(range(n_frames_to_read)):
+        #    ret, frame = video.read()
+        #    gray=cv2.cvtColor(frame,cv2.COLOR_BGR2GRAY)
+        #    frames.append(gray)
+        #    key = cv2.waitKey(1)
 
         #annotate frames with previous labels
         batch_labels = labels[((labels.frame >= batch_start_frame) &


### PR DESCRIPTION
Modified videolabeler.batchFrameLabel() and videolabeler.relabelFrames() to load videos frame-by-frame using video.set() instead of via streaming with video.read()